### PR TITLE
kas: ewaol: Add debug yaml file

### DIFF
--- a/kas/ewaol/debug.yml
+++ b/kas/ewaol/debug.yml
@@ -1,0 +1,6 @@
+header:
+  version: 11
+
+local_conf_header:
+  ewaol-base: |
+    CORE_IMAGE_EXTRA_INSTALL += "trace-cmd perf"


### PR DESCRIPTION
We can add debug utilities in the building, like trace-cmd, perf tools;
this patch adds a new kas yaml for enabling debugging tools, and later
we can easily extend for more debugging tools in this yaml file.

Signed-off-by: Leo Yan <leo.yan@linaro.org>