### PR TITLE
kas: ewaol: avadp: Add yaml file for pure BSP building

### DIFF
--- a/kas/machine/avadp-xfce.yml
+++ b/kas/machine/avadp-xfce.yml
@@ -1,29 +1,21 @@
 header:
   version: 11
+  includes:
+    - avadp.yml
 
 repos:
-  meta-adlink-ampere:
-    url: "https://github.com/ADLINK/meta-adlink-ampere.git"
-    refspec: kirkstone
-    path: layers/meta-adlink-ampere
-    layers:
-      .:
-
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     refspec: kirkstone
     path: layers/meta-openembedded
     layers:
       meta-xfce:
-      meta-oe:
       meta-gnome:
       meta-multimedia:
 
-machine: ava
-
 local_conf_header:
-  meta-at: |
+  meta-at-xfce: |
     XSERVER:append = " xserver-xorg-extension-glx xserver-xorg-module-libwfb xserver-xorg-module-exa"
-    IMAGE_INSTALL:append = " packagegroup-core-x11 packagegroup-xfce-base acpid xf86-video-modesetting mesa-demos"
+    IMAGE_INSTALL:append = " packagegroup-core-x11 packagegroup-xfce-base xf86-video-modesetting mesa-demos"
     DISTRO_FEATURES:append = " opengl x11 glx"
-    PACKAGECONFIG:append:pn-xserver-xorg = " xinerama"    
+    PACKAGECONFIG:append:pn-xserver-xorg = " xinerama"

--- a/kas/machine/avadp.yml
+++ b/kas/machine/avadp.yml
@@ -1,0 +1,23 @@
+header:
+  version: 11
+
+repos:
+  meta-adlink-ampere:
+    url: "https://github.com/ADLINK/meta-adlink-ampere.git"
+    refspec: kirkstone
+    path: layers/meta-adlink-ampere
+    layers:
+      .:
+
+  meta-openembedded:
+    url: "https://github.com/openembedded/meta-openembedded.git"
+    refspec: kirkstone
+    path: layers/meta-openembedded
+    layers:
+      meta-oe:
+
+machine: ava
+
+local_conf_header:
+  meta-at: |
+    IMAGE_INSTALL:append = " acpid"


### PR DESCRIPTION
avadp-xfce.yml includes packages for X-server and graphics system, in
some cases users only want to build BSP for AVA platform.

For this reason, this patch introduces a new avadp.yml file, it enables
only necessary packages for ADLINK BSP meta layer, this yaml file is
included by avadp-xfce.yml and avadp-xfce.yml extends the building for
graphic system.

Signed-off-by: Leo Yan <leo.yan@linaro.org>