### PR TITLE
Fix. branch name in SRC_URI for nvidia-container-toolkit recipe

### DIFF
--- a/meta-ewaol-ext/recipes-ewaol/recipes-container/nvidia-container-toolkit/nvidia-container-toolkit_1.7.0.bb
+++ b/meta-ewaol-ext/recipes-ewaol/recipes-container/nvidia-container-toolkit/nvidia-container-toolkit_1.7.0.bb
@@ -8,7 +8,7 @@ DEPENDS = "libnvidia-container go-native"
 CLEANBROKEN = "1"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI = "git://github.com/NVIDIA/nvidia-container-toolkit;branch=master;protocol=https \
+SRC_URI = "git://github.com/NVIDIA/nvidia-container-toolkit;branch=main;protocol=https \
            file://0001-Add-GOARCH-customization.patch"
 
 SRCREV = "f10f533fb21ee4cd7c298681fc61cc5a1aa09551"


### PR DESCRIPTION
Got this error while `do_fetch()` function for the nvidia-container-toolkit recipe. It seems that there is no branch master in the toolkit official repo. Once Changed this branch name, the build is working. 
Error: ```nvidia-container-toolkit-1.7.0-r0 do_fetch: Fetcher failure: Unable to find revision f10f533fb21ee4cd7c298681fc61cc5a1aa09551 in branch master even from upstream```